### PR TITLE
Fix loading in engines

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,12 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
     if (process.env.EMBER_CLI_FASTBOOT !== 'true') {
+
+      // Fix for loading it in addons/engines
+      if (typeof app.import !== 'function' && app.app) {
+        app = app.app;
+      }
+
       app.import(app.bowerDirectory + '/d3/d3.js');
       app.import('vendor/ember-d3/ember-d3-shim.js', {
         exports: {


### PR DESCRIPTION
When used in an engine, app.import was not available and failed. This PR fixes this and makes it possible to use ember-d3 in engines.