### PR TITLE
Fix import for engines

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,13 +10,10 @@ module.exports = {
     this._super.included(app);
     if (process.env.EMBER_CLI_FASTBOOT !== 'true') {
 
-      // Fix for loading it in addons/engines
-      if (typeof app.import !== 'function' && app.app) {
-        app = app.app;
-      }
+      var bowerDirectory = app.bowerDirectory || 'bower_components';
 
-      app.import(app.bowerDirectory + '/d3/d3.js');
-      app.import('vendor/ember-d3/ember-d3-shim.js', {
+      this.import(bowerDirectory + '/d3/d3.js');
+      this.import('vendor/ember-d3/ember-d3-shim.js', {
         exports: {
           d3: ['default']
         }

--- a/index.js
+++ b/index.js
@@ -9,11 +9,13 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
     if (process.env.EMBER_CLI_FASTBOOT !== 'true') {
-
+      // In nested addons, app.bowerDirectory might not be available
       var bowerDirectory = app.bowerDirectory || 'bower_components';
+      // In ember-cli < 2.7, this.import is not available, so fall back to use app.import
+      var importShim = typeof this.import !== 'undefined' ? this : app;
 
-      this.import(bowerDirectory + '/d3/d3.js');
-      this.import('vendor/ember-d3/ember-d3-shim.js', {
+      importShim.import(bowerDirectory + '/d3/d3.js');
+      importShim.import('vendor/ember-d3/ember-d3-shim.js', {
         exports: {
           d3: ['default']
         }


### PR DESCRIPTION
After upgrading to ember-cli@2.7, this started to make problems again. 

In ember.cli@2.7, this.import is now available for exactly this purpose. But this.import fails in older ember-cli versions.

I added a check to use app.import if this.import is not available. This means that it should continue working for everyone, but if you want to use it in a nested addon/engine, you will be required to use either ember-cli >= 2.7. or install https://github.com/ember-cli/ember-cli-import-polyfill.

Sorry for the duplicate work - the prior fix worked fine in ember-cli@2.6, but stopped working for me after upgrading the host app.