### PR TITLE
bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-d3",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Ember CLI addon to include D3 as an ES2015 module in your app.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Unless I'm missing something, 0.3.0 was published on npm, so this one should the same.
