### PR TITLE
Use "var" instead of "let"

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ module.exports = {
     var trees = [];
 
     if (tree) {
-      let versionTree = new RecastFilter(tree, null, replaceVersionString, {
+      var versionTree = new RecastFilter(tree, null, replaceVersionString, {
         version: d3Version('d3', this.parent.nodeModulesPath)
       });
 

--- a/lib/replace-version-string.js
+++ b/lib/replace-version-string.js
@@ -5,7 +5,7 @@ var types = recast.types;
 var b = recast.types.builders;
 
 module.exports = function replaceVersionString(code, packageName, options) {
-  let version = options.version;
+  var version = options.version;
 
   var ast = recast.parse(code);
   types.visit(ast, {


### PR DESCRIPTION
Latest release (0.3.1) introduced use of `let` in 2 places which resulted in this error:

```SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode```

when Node < 6. I've changed them to `var` to keep addon compatible with older Node versions.