### PR TITLE
Fix package name checking for svelte builds.

### DIFF
--- a/lib/inclusion-filter.js
+++ b/lib/inclusion-filter.js
@@ -1,9 +1,6 @@
-module.exports = function inclusionFilter(packages) {
-  return function(packageName) {
-    if (packages.length === 0) { return true; }
-
-    return packages.map(function(pkg) {
-      return pkg.name;
-    }).indexOf(packageName) > -1;
+module.exports = function inclusionFilter(packageNames) {
+  return function(pkg) {
+    if (packageNames.length === 0) { return true; }
+    return packageNames.indexOf(pkg.name) > -1;
   };
 };


### PR DESCRIPTION
Making svelte builds doesn't work currently. The thing that is passed to inclusionFilter is config.only (see here: https://github.com/brzpegasus/ember-d3/blob/master/index.js#L82), which is an array of package names strings, not package objects, which the old code seems to assume. This fixes that bug.